### PR TITLE
Add bblock extractor

### DIFF
--- a/ffi/transforms.cpp
+++ b/ffi/transforms.cpp
@@ -1,7 +1,13 @@
 #include "core.h"
+#include "llvm/IR/Function.h"
+#include "llvm-c/Core.h"
 #include "llvm-c/Target.h"
 #include "llvm-c/Transforms/PassManagerBuilder.h"
 #include "llvm/Transforms/IPO/PassManagerBuilder.h"
+#include <llvm-c/Types.h>
+#include <llvm/IR/BasicBlock.h>
+#include <llvm/Support/ErrorHandling.h>
+#include <llvm/Transforms/Utils/CodeExtractor.h>
 
 extern "C" {
 
@@ -91,6 +97,46 @@ API_EXPORT(int)
 LLVMPY_PassManagerBuilderGetSLPVectorize(LLVMPassManagerBuilderRef PMB) {
     llvm::PassManagerBuilder *pmb = llvm::unwrap(PMB);
     return pmb->SLPVectorize;
+}
+
+// Extracts a single basic block from a function using the CodeExtractor
+// interface.
+API_EXPORT(LLVMValueRef)
+LLVMPY_ExtractBasicBlock(LLVMValueRef Func, LLVMValueRef BBlock) {
+
+    llvm::Function *Fn = llvm::dyn_cast<llvm::Function>(llvm::unwrap(Func));
+    if (!Fn)
+        llvm::report_fatal_error((std::string(__FILE__) + ":" +
+                                  std::to_string(__LINE__) +
+                                  "Expected function")
+                                     .c_str());
+
+    llvm::BasicBlock *BB = llvm::dyn_cast<llvm::BasicBlock>(llvm::unwrap(BBlock));
+    if (!BB)
+        llvm::report_fatal_error((std::string(__FILE__) + ":" +
+                                  std::to_string(__LINE__) +
+                                  "Expected basic block")
+                                     .c_str());
+
+    llvm::CodeExtractorAnalysisCache CEAC{*Fn};
+    llvm::CodeExtractor Extractor{{BB},
+                                  /* DominatorTree */ nullptr,
+                                  /* AggregateArgs */ false,
+                                  /* BlockFrequencyInfo */ nullptr,
+                                  /* BranchProbabilityInfo */ nullptr,
+                                  /* AssumptionCache */ nullptr,
+                                  /* AllowVarArgs */ false,
+                                  /* AllowAlloca */ true,
+                                  /* Suffix */ "bblock_extract"};
+    llvm::Function *Outlined = Extractor.extractCodeRegion(CEAC);
+    std::string FnName = Outlined->getName().str();
+    // Remove '.' added by extractor in function name to avoid invalid function
+    // names in C.
+    std::replace(FnName.begin(), FnName.end(), '.', '_');
+    Outlined->setName(FnName);
+    if (Outlined == nullptr)
+        llvm::report_fatal_error("extractCodeRegion failed, not eligible");
+    return llvm::wrap(Outlined);
 }
 
 } // end extern "C"

--- a/llvmlite/binding/value.py
+++ b/llvmlite/binding/value.py
@@ -687,3 +687,6 @@ ffi.lib.LLVMPY_GetConstantSequenceElement.restype = ffi.LLVMValueRef
 
 ffi.lib.LLVMPY_GetConstantSequenceNumElements.argtypes = [ffi.LLVMValueRef]
 ffi.lib.LLVMPY_GetConstantSequenceNumElements.restype = c_size_t
+
+ffi.lib.LLVMPY_ExtractBasicBlock.argtypes = [ffi.LLVMValueRef, ffi.LLVMValueRef]
+ffi.lib.LLVMPY_ExtractBasicBlock.restype = ffi.LLVMValueRef

--- a/llvmlite/ir/transforms.py
+++ b/llvmlite/ir/transforms.py
@@ -1,4 +1,6 @@
 from llvmlite.ir import CallInstr
+from llvmlite.binding import ffi
+from llvmlite.binding.value import ValueRef
 
 
 class Visitor(object):
@@ -62,3 +64,8 @@ def replace_all_calls(mod, orig, repl):
     rc = ReplaceCalls(orig, repl)
     rc.visit(mod)
     return rc.calls
+
+
+def extract_bblock(mod, func, block):
+    return ValueRef(ffi.lib.LLVMPY_ExtractBasicBlock(func, block), "function",
+                    dict(module=mod))


### PR DESCRIPTION
Adds an interface to CodeExtractor to extract a single basic block as a function.